### PR TITLE
Fix social proof overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,13 +96,13 @@
 
   <section id="social-proof" class="py-16 overflow-hidden bg-white/5">
     <div class="relative flex">
-      <ul class="flex space-x-8 whitespace-nowrap animate-marquee">
+      <ul class="flex space-x-8 flex-nowrap animate-marquee">
         <li class="flex-shrink-0 w-80 italic text-gray-400">“Our bookings jumped 27% in the first month after launch. Customers tell us the site ‘just feels better’ than other local shops.” — Carla M.</li>
         <li class="flex-shrink-0 w-80 italic text-gray-400">“I’d put off web stuff for years; they handled everything in three days and even fixed my domain mess. It loads lightning-fast on weak LTE.” — Ramon P.</li>
         <li class="flex-shrink-0 w-80 italic text-gray-400">“Google picked us up within a week and we outrank the chains now. That monthly Care plan saves me hours.” — Janelle O.</li>
         <li class="flex-shrink-0 w-80 italic text-gray-400">“We got compliments on the site before we even announced it. One client said it looked like we franchised overnight. Worth every penny.” — Kevin D.</li>
       </ul>
-      <ul class="flex space-x-8 whitespace-nowrap animate-marquee absolute left-full" aria-hidden="true">
+      <ul class="flex space-x-8 flex-nowrap animate-marquee absolute left-full" aria-hidden="true">
         <li class="flex-shrink-0 w-80 italic text-gray-400">“Our bookings jumped 27% in the first month after launch. Customers tell us the site ‘just feels better’ than other local shops.” — Carla M.</li>
         <li class="flex-shrink-0 w-80 italic text-gray-400">“I’d put off web stuff for years; they handled everything in three days and even fixed my domain mess. It loads lightning-fast on weak LTE.” — Ramon P.</li>
         <li class="flex-shrink-0 w-80 italic text-gray-400">“Google picked us up within a week and we outrank the chains now. That monthly Care plan saves me hours.” — Janelle O.</li>


### PR DESCRIPTION
## Summary
- remove `whitespace-nowrap` from marquee lists to allow text wrapping
- keep items in one row with `flex-nowrap`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6858929dca448329b2ff2ad854521af6