### PR TITLE
Remove hero header animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     .underline-accent:hover::after { transform: scaleX(1); }
 
     /* animated gradient for "Guru" text */
+
     .guru-gradient {
       background: linear-gradient(90deg, #facc15, #a855f7, #22d3ee, #facc15);
       background-size: 300% 100%;
@@ -34,6 +35,15 @@
               background-clip: text;
       color: transparent;
       animation: gradient-shift 6s linear infinite;
+    }
+
+    /* static gradient without animation */
+    .guru-static {
+      background: linear-gradient(90deg, #facc15, #a855f7, #22d3ee, #facc15);
+      background-size: 300% 100%;
+      -webkit-background-clip: text;
+              background-clip: text;
+      color: transparent;
     }
 
     .see-pricing:hover {
@@ -82,7 +92,7 @@
   <section class="hero h-screen flex flex-col justify-center items-center text-center px-6 relative">
     <div class="absolute inset-0 bg-gradient-to-br from-white/5 via-white/0 to-white/5 pointer-events-none"></div>
 
-    <h2 class="text-4xl md:text-6xl font-extrabold tracking-wide mb-6">Ready for <span class="guru-gradient">Launch</span>?</h2>
+    <h2 class="text-4xl md:text-6xl font-extrabold tracking-wide mb-6">Ready for <span class="guru-static">Launch</span>?</h2>
     <p class="text-lg md:text-2xl max-w-xl text-gray-300">
       Ultra-fast, stunning single-page sites for local businesses.
       Built, hosted & handed over in days—not weeks.


### PR DESCRIPTION
## Summary
- add a new `guru-static` CSS class for a non-animated gradient
- use that class on the hero heading so the gradient no longer animates

## Testing
- `npm test` *(fails: cannot find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685892a74d688329b354a33bed1272d6