### PR TITLE
Remove colored hero Launch text

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
   <section class="hero h-screen flex flex-col justify-center items-center text-center px-6 relative section-alt-1">
     <div class="absolute inset-0 bg-gradient-to-br from-white/5 via-white/0 to-white/5 pointer-events-none"></div>
 
-    <h2 class="text-4xl md:text-6xl font-extrabold tracking-wide mb-6">Ready for <span class="guru-static">Launch</span>?</h2>
+    <h2 class="text-4xl md:text-6xl font-extrabold tracking-wide mb-6">Ready for Launch?</h2>
     <p class="text-lg md:text-2xl max-w-xl text-gray-300">
       Ultra-fast, stunning single-page sites for local businesses.
       Built, hosted & handed over in days—not weeks.


### PR DESCRIPTION
## Summary
- remove gradient span from "Launch" hero caption

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858946673888329983ca6738dcae57c