### PR TITLE
Fix social proof marquee alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,14 +113,14 @@
 
 
   <section id="social-proof" class="py-16 overflow-hidden section-alt-2">
-    <div class="relative flex">
+    <div class="relative flex w-max">
       <ul class="flex space-x-8 flex-nowrap animate-marquee">
         <li class="flex-shrink-0 w-80 italic text-gray-400">“Our bookings jumped 27% in the first month after launch. Customers tell us the site ‘just feels better’ than other local shops.” — Carla M.</li>
         <li class="flex-shrink-0 w-80 italic text-gray-400">“I’d put off web stuff for years; they handled everything in three days and even fixed my domain mess. It loads lightning-fast on weak LTE.” — Ramon P.</li>
         <li class="flex-shrink-0 w-80 italic text-gray-400">“Google picked us up within a week and we outrank the chains now. That monthly Care plan saves me hours.” — Janelle O.</li>
         <li class="flex-shrink-0 w-80 italic text-gray-400">“We got compliments on the site before we even announced it. One client said it looked like we franchised overnight. Worth every penny.” — Kevin D.</li>
       </ul>
-      <ul class="flex space-x-8 flex-nowrap animate-marquee absolute left-full" aria-hidden="true">
+      <ul class="flex space-x-8 flex-nowrap animate-marquee absolute left-0 translate-x-full" aria-hidden="true">
         <li class="flex-shrink-0 w-80 italic text-gray-400">“Our bookings jumped 27% in the first month after launch. Customers tell us the site ‘just feels better’ than other local shops.” — Carla M.</li>
         <li class="flex-shrink-0 w-80 italic text-gray-400">“I’d put off web stuff for years; they handled everything in three days and even fixed my domain mess. It loads lightning-fast on weak LTE.” — Ramon P.</li>
         <li class="flex-shrink-0 w-80 italic text-gray-400">“Google picked us up within a week and we outrank the chains now. That monthly Care plan saves me hours.” — Janelle O.</li>


### PR DESCRIPTION
## Summary
- ensure social proof marquee clone starts in correct position
- keep testimonial wrapper width equal to marquee content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685896107d3c83298ae5cc707fd5eae7