### PR TITLE
Set overscroll bottom color

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
 
   <!-- Custom tweaks -->
   <style>
-    html { scroll-padding-top: 72px; }
+    html {
+      scroll-padding-top: 72px;
+      background-color: #ffffff;
+    }
     /* optional accent for hover underline */
     .underline-accent {
       position: relative;


### PR DESCRIPTION
## Summary
- make overscrolling past the footer show a white background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68589b4d32ac8329bff60a79cc045e63