### PR TITLE
Match footer background with grey sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <style>
     html {
       scroll-padding-top: 72px;
-      background-color: #000000;
+      background-color: #111111;
     }
     /* optional accent for hover underline */
     .underline-accent {
@@ -352,7 +352,7 @@
   </section>
 
   <!-- ===== Footer ===== -->
-  <footer class="py-6 text-center text-xs bg-black text-gray-400 border-t border-white/10">
+  <footer class="py-6 text-center text-xs text-gray-400 border-t border-white/10 section-alt-2">
     © 2024 Liftoff Guru — All rights reserved.
   </footer>
 


### PR DESCRIPTION
## Summary
- use same grey background as section-alt-2
- adjust page default background to grey

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858a64822148329b1222ba36490ed02