### PR TITLE
Fix mobile menu when external scripts fail

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,8 +372,11 @@
   <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
   <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
   <script>
-    AOS.init();
-    new Swiper('.testimonials-swiper', {
+    if (window.AOS) {
+      AOS.init();
+    }
+    if (window.Swiper) {
+      new Swiper('.testimonials-swiper', {
       loop: true,
       autoplay: { delay: 5000, disableOnInteraction: false },
       allowTouchMove: false,


### PR DESCRIPTION
## Summary
- guard Swiper and AOS calls so nav script runs even if those libraries fail to load

## Testing
- `tidy -qe index.html`

------
https://chatgpt.com/codex/tasks/task_e_6858af4a2c5c83298dac7eddd64a874a