### PR TITLE
Fix mobile menu items

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
 
       <button id="nav-toggle" class="md:hidden p-2 text-3xl focus:outline-none" aria-label="Toggle navigation">&#9776;</button>
 
-      <ul class="hidden md:flex space-x-8 uppercase text-sm">
+      <ul id="desktop-menu" class="hidden md:flex space-x-8 uppercase text-sm">
         <li><a href="#social-proof" class="underline-accent">Reviews</a></li>
         <li><a href="#process"      class="underline-accent">Process</a></li>
         <li><a href="#pricing"      class="underline-accent">Pricing</a></li>
@@ -97,14 +97,7 @@
         <li><a href="#contact"      class="underline-accent">Contact</a></li>
       </ul>
     </nav>
-    <ul id="nav-menu" class="md:hidden fixed inset-0 hidden flex flex-col items-center justify-center space-y-8 text-lg uppercase bg-black/90">
-      <li><a href="#social-proof" class="underline-accent">Reviews</a></li>
-      <li><a href="#process"      class="underline-accent">Process</a></li>
-      <li><a href="#pricing"      class="underline-accent">Pricing</a></li>
-      <li><a href="#faq"          class="underline-accent">FAQs</a></li>
-      <li><a href="#portfolio"    class="underline-accent">Portfolio</a></li>
-      <li><a href="#contact"      class="underline-accent">Contact</a></li>
-    </ul>
+    <ul id="nav-menu" class="md:hidden fixed inset-0 hidden flex flex-col items-center justify-center space-y-8 text-lg uppercase bg-black/90"></ul>
   </header>
 
   <!-- ===== Hero ===== -->
@@ -397,7 +390,11 @@
     window.addEventListener('load', updateScrollPadding);
     window.addEventListener('resize', updateScrollPadding);
     const toggle = document.getElementById('nav-toggle');
+    const desktopMenu = document.getElementById('desktop-menu');
     const mobileMenu = document.getElementById('nav-menu');
+    if (desktopMenu && mobileMenu && mobileMenu.innerHTML.trim() === '') {
+      mobileMenu.innerHTML = desktopMenu.innerHTML;
+    }
     const barsIcon = toggle.innerHTML;
     const closeIcon = '&times;';
     toggle.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- keep mobile and desktop nav items in sync by cloning the desktop list

## Testing
- `htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_6858b1f048e48329af6030c0cdee9bff