### PR TITLE
Remove unused mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,9 +86,7 @@
         <a href="#top" onclick="document.documentElement.scrollTo({top:0,behavior:'auto'});">Liftoff.<span class="guru-gradient">Guru</span></a>
       </h1>
 
-      <button id="nav-toggle" class="md:hidden p-2 text-3xl focus:outline-none" aria-label="Toggle navigation">&#9776;</button>
-
-      <ul id="desktop-menu" class="hidden md:flex space-x-8 uppercase text-sm">
+      <ul id="main-menu" class="flex space-x-4 md:space-x-8 uppercase text-sm">
         <li><a href="#social-proof" class="underline-accent">Reviews</a></li>
         <li><a href="#process"      class="underline-accent">Process</a></li>
         <li><a href="#pricing"      class="underline-accent">Pricing</a></li>
@@ -97,7 +95,6 @@
         <li><a href="#contact"      class="underline-accent">Contact</a></li>
       </ul>
     </nav>
-    <ul id="nav-menu" class="md:hidden fixed inset-0 hidden flex flex-col items-center justify-center space-y-8 text-lg uppercase bg-black/90"></ul>
   </header>
 
   <!-- ===== Hero ===== -->
@@ -389,24 +386,6 @@
     }
     window.addEventListener('load', updateScrollPadding);
     window.addEventListener('resize', updateScrollPadding);
-    const toggle = document.getElementById('nav-toggle');
-    const desktopMenu = document.getElementById('desktop-menu');
-    const mobileMenu = document.getElementById('nav-menu');
-    if (desktopMenu && mobileMenu && mobileMenu.innerHTML.trim() === '') {
-      mobileMenu.innerHTML = desktopMenu.innerHTML;
-    }
-    const barsIcon = toggle.innerHTML;
-    const closeIcon = '&times;';
-    toggle.addEventListener('click', () => {
-      mobileMenu.classList.toggle('hidden');
-      toggle.innerHTML = mobileMenu.classList.contains('hidden') ? barsIcon : closeIcon;
-    });
-    mobileMenu.querySelectorAll('a').forEach(link => link.addEventListener('click', () => {
-      if (!mobileMenu.classList.contains('hidden')) {
-        mobileMenu.classList.add('hidden');
-        toggle.innerHTML = barsIcon;
-      }
-    }));
   </script>
 
 </body>


### PR DESCRIPTION
## Summary
- take out the mobile nav toggle and menu
- strip the JavaScript that handled mobile navigation
- show navigation links at all screen sizes

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858b393003c8329ba1a6c698ae0cbb5